### PR TITLE
Prototype Yjs-backed scene graph with versioning demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.DS_Store
+*.log
+examples/updates/

--- a/examples/merge-demo.js
+++ b/examples/merge-demo.js
@@ -1,0 +1,54 @@
+const Y = require('yjs');
+const THREE = require('three');
+const path = require('path');
+const { sceneToDoc, docToScene } = require('../src/sceneGraph');
+const { persistUpdates, loadUpdates, replayUpdates } = require('../src/versioning');
+
+// Create initial scene with one cube
+const scene = new THREE.Scene();
+const cube = new THREE.Mesh(
+  new THREE.BoxGeometry(),
+  new THREE.MeshBasicMaterial({ color: 0x00ff00 })
+);
+scene.add(cube);
+
+// Build initial Yjs document
+const doc1 = sceneToDoc(scene);
+const updateInit = Y.encodeStateAsUpdate(doc1);
+
+// Clone document for second editor
+const doc2 = new Y.Doc();
+Y.applyUpdate(doc2, updateInit);
+
+// Local change on doc1: move cube on X axis
+const sv1 = Y.encodeStateVector(doc1);
+const cube1 = doc1.getMap('scene').get('root').get('children').get(0);
+cube1.get('position').set('x', 1);
+const update1 = Y.encodeStateAsUpdate(doc1, sv1);
+
+// Local change on doc2: move cube on Y axis
+const sv2 = Y.encodeStateVector(doc2);
+const cube2 = doc2.getMap('scene').get('root').get('children').get(0);
+cube2.get('position').set('y', 2);
+const update2 = Y.encodeStateAsUpdate(doc2, sv2);
+
+// Exchange updates (merging)
+Y.applyUpdate(doc1, update2);
+Y.applyUpdate(doc2, update1);
+
+// Convert merged doc back to three.js scene
+const mergedScene = docToScene(doc1);
+const mergedPos = mergedScene.children[0].position;
+console.log('Merged position:', mergedPos.x, mergedPos.y, mergedPos.z);
+
+// Persist updates
+const updatesDir = path.join(__dirname, 'updates');
+persistUpdates([updateInit, update1, update2], updatesDir);
+
+// Replay updates into a new document
+const loaded = loadUpdates(updatesDir);
+const docReplayed = new Y.Doc();
+replayUpdates(loaded, docReplayed);
+const sceneReplayed = docToScene(docReplayed);
+const posReplay = sceneReplayed.children[0].position;
+console.log('Replayed position:', posReplay.x, posReplay.y, posReplay.z);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,71 @@
+{
+  "name": "vibecodingexperiment",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vibecodingexperiment",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "three": "^0.179.1",
+        "yjs": "^13.6.27"
+      }
+    },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.114",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
+      "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.179.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.179.1.tgz",
+      "integrity": "sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==",
+      "license": "MIT"
+    },
+    "node_modules/yjs": {
+      "version": "13.6.27",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
+      "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "vibecodingexperiment",
+  "version": "1.0.0",
+  "description": "ohboy",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "three": "^0.179.1",
+    "yjs": "^13.6.27"
+  }
+}

--- a/src/sceneGraph.js
+++ b/src/sceneGraph.js
@@ -1,0 +1,72 @@
+const Y = require('yjs');
+const THREE = require('three');
+
+function serializeNode(node) {
+  const yNode = new Y.Map();
+  yNode.set('id', node.uuid);
+  yNode.set('type', node.type);
+
+  const pos = new Y.Map();
+  pos.set('x', node.position.x);
+  pos.set('y', node.position.y);
+  pos.set('z', node.position.z);
+  yNode.set('position', pos);
+
+  if (node.material && node.material.color) {
+    yNode.set('material', node.material.color.getHex());
+  }
+
+  const children = new Y.Array();
+  for (const child of node.children) {
+    children.push([serializeNode(child)]);
+  }
+  yNode.set('children', children);
+  return yNode;
+}
+
+function sceneToDoc(scene) {
+  const doc = new Y.Doc();
+  const root = serializeNode(scene);
+  doc.getMap('scene').set('root', root);
+  return doc;
+}
+
+function deserializeNode(yNode) {
+  const type = yNode.get('type');
+  let obj;
+  if (type === 'Scene') {
+    obj = new THREE.Scene();
+  } else if (type === 'Mesh') {
+    const color = yNode.get('material') || 0xffffff;
+    const geometry = new THREE.BoxGeometry();
+    const material = new THREE.MeshBasicMaterial({ color });
+    obj = new THREE.Mesh(geometry, material);
+  } else {
+    obj = new THREE.Object3D();
+  }
+
+  const pos = yNode.get('position');
+  if (pos) {
+    obj.position.set(pos.get('x') || 0, pos.get('y') || 0, pos.get('z') || 0);
+  }
+
+  const children = yNode.get('children');
+  if (children) {
+    children.forEach(yChild => {
+      const childObj = deserializeNode(yChild);
+      obj.add(childObj);
+    });
+  }
+
+  return obj;
+}
+
+function docToScene(doc) {
+  const root = doc.getMap('scene').get('root');
+  if (!root) {
+    return new THREE.Scene();
+  }
+  return deserializeNode(root);
+}
+
+module.exports = { sceneToDoc, docToScene };

--- a/src/versioning.js
+++ b/src/versioning.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const Y = require('yjs');
+
+function persistUpdates(updates, dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  updates.forEach((u, idx) => {
+    const file = path.join(dir, `update-${idx}.bin`);
+    fs.writeFileSync(file, Buffer.from(u));
+  });
+}
+
+function loadUpdates(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const files = fs.readdirSync(dir)
+    .filter(f => f.endsWith('.bin'))
+    .sort();
+  return files.map(f => fs.readFileSync(path.join(dir, f)));
+}
+
+function replayUpdates(updates, doc) {
+  updates.forEach(u => Y.applyUpdate(doc, u));
+}
+
+module.exports = { persistUpdates, loadUpdates, replayUpdates };


### PR DESCRIPTION
## Summary
- add helpers to serialize three.js scene graphs into Yjs documents and back
- implement simple update persistence and replay helpers
- include merge-demo script showcasing concurrent edits and update replay

## Testing
- `node examples/merge-demo.js`

------
https://chatgpt.com/codex/tasks/task_e_68a72680b58c83239b5c576f0e00c91e